### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Install Node
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v5.0.0
         with:
           node-version: node
 
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v4.2.4
+      - uses: actions/cache@v4.3.0
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v5.0.0](https://github.com/actions/setup-node/releases/tag/v5.0.0)** on 2025-09-04T02:52:29Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.3.0](https://github.com/actions/cache/releases/tag/v4.3.0)** on 2025-09-24T13:48:50Z
